### PR TITLE
Fix error msg on invalid mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ The `values` property is a convenience function that provides a tuple of human-r
 * `temperature`:  the temperature in hundredths of a degree celsius. For example, the value 2534  indicates a temperature of 25.34 degrees.
 * `pressure`: the atmospheric pressure. This 32-bit value consists of 24 bits indicating the integer value, and 8 bits indicating the fractional value. To get a value in Pascals, divide the return value by 256. For example, a value of 24674867 indicates 96386.2Pa, or 963.862hPa.
 * `humidity`: the relative humidity. This 32-bit value consists of 22 bits indicating the integer value, and 10 bits indicating the fractional value. To get a value in %RH, divide the return value by 1024. For example, a value of 47445 indicates 46.333%RH.
+
+The BME280 constructor takes an optional `address` argument. BME280 devices are
+on I2C addresses 0x76 or 0x77. If you do not provide an address the driver will
+scan for a device and use it, raising an exception if no device is found.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# This fork
+
+I created this to raise a [PR](https://github.com/catdog2/mpy_bme280_esp8266/pull/9)
+against the master. Unfortunately the master seems to have been abandoned. My PR and
+other apparently good ones have been ignored. Please read the PR's epecially
+[this bugfix](https://github.com/catdog2/mpy_bme280_esp8266/pull/11).
+
 # README #
 
 This is a driver for the Bosch BME280 temperature/pressure/humidity sensor, for use with MicroPython on ESP8266 boards. It is also compatible with the BMP280 which provides the same interface but temperature + pressure only.

--- a/bme280.py
+++ b/bme280.py
@@ -152,7 +152,7 @@ class BME280:
         self.read_raw_data(self._l3_resultarray)
         raw_temp, raw_press, raw_hum = self._l3_resultarray
         # temperature
-        var1 = ((raw_temp >> 3) - (self.dig_T1 << 1)) * (self.dig_T2 >> 11)
+        var1 = (((raw_temp >> 3) - (self.dig_T1 << 1)) * self.dig_T2) >> 11
         var2 = (((((raw_temp >> 4) - self.dig_T1) *
                   ((raw_temp >> 4) - self.dig_T1)) >> 12) * self.dig_T3) >> 14
         self.t_fine = var1 + var2

--- a/bme280.py
+++ b/bme280.py
@@ -37,8 +37,8 @@ from ustruct import unpack, unpack_from
 from array import array
 from micropython import const
 
-# BME280 default address.
-BME280_I2CADDR = const(0x76)
+# BME280 default addresses.
+BME280_I2CADDRS = (0x76, 0x77)
 
 # Operating Modes
 BME280_OSAMPLE_1 = const(1)
@@ -55,23 +55,29 @@ class BME280:
 
     def __init__(self,
                  mode=BME280_OSAMPLE_1,
-                 address=BME280_I2CADDR,
+                 address=None,
                  i2c=None):
         # Check that mode is valid.
-        if mode not in range(1,6):
+        if mode < BME280_OSAMPLE_1 or mode > BME280_OSAMPLE_16:
             raise ValueError(
                 'Unexpected mode value {0}. Set mode to one of '
                 'BME280_OSAMPLE_1, BME280_OSAMPLE_2, BME280_OSAMPLE_4, '
                 'BME280_OSAMPLE_8 or BME280_OSAMPLE_16'.format(mode))
         self._mode = mode
-        self.address = address
         if i2c is None:
             raise ValueError('An I2C object is required.')
+        if address is not None:
+            self.address = address
+        else:
+            addr = [a for a in i2c.scan() if a in BME280_I2CADDRS]
+            if len(addr) == 0:
+                raise RuntimeError('No BME280 found.')
+            self.address = addr[0]  # 1st device found
         self.i2c = i2c
 
         # load calibration data
-        dig_88_a1 = self.i2c.readfrom_mem(self.address, 0x88, 26)
-        dig_e1_e7 = self.i2c.readfrom_mem(self.address, 0xE1, 7)
+        dig_88_a1 = i2c.readfrom_mem(self.address, 0x88, 26)
+        dig_e1_e7 = i2c.readfrom_mem(self.address, 0xE1, 7)
         self.dig_T1, self.dig_T2, self.dig_T3, self.dig_P1, \
             self.dig_P2, self.dig_P3, self.dig_P4, self.dig_P5, \
             self.dig_P6, self.dig_P7, self.dig_P8, self.dig_P9, \
@@ -86,7 +92,7 @@ class BME280:
 
         self.dig_H6 = unpack_from("<b", dig_e1_e7, 6)[0]
 
-        self.i2c.writeto_mem(self.address, BME280_REGISTER_CONTROL,
+        i2c.writeto_mem(self.address, BME280_REGISTER_CONTROL,
                              bytearray([0x3F]))
         self.t_fine = 0
 

--- a/bme280.py
+++ b/bme280.py
@@ -35,19 +35,20 @@
 import time
 from ustruct import unpack, unpack_from
 from array import array
+from micropython import const
 
 # BME280 default address.
-BME280_I2CADDR = 0x76
+BME280_I2CADDR = const(0x76)
 
 # Operating Modes
-BME280_OSAMPLE_1 = 1
-BME280_OSAMPLE_2 = 2
-BME280_OSAMPLE_4 = 3
-BME280_OSAMPLE_8 = 4
-BME280_OSAMPLE_16 = 5
+BME280_OSAMPLE_1 = const(1)
+BME280_OSAMPLE_2 = const(2)
+BME280_OSAMPLE_4 = const(3)
+BME280_OSAMPLE_8 = const(4)
+BME280_OSAMPLE_16 = const(5)
 
-BME280_REGISTER_CONTROL_HUM = 0xF2
-BME280_REGISTER_CONTROL = 0xF4
+BME280_REGISTER_CONTROL_HUM = const(0xF2)
+BME280_REGISTER_CONTROL = const(0xF4)
 
 
 class BME280:
@@ -55,15 +56,13 @@ class BME280:
     def __init__(self,
                  mode=BME280_OSAMPLE_1,
                  address=BME280_I2CADDR,
-                 i2c=None,
-                 **kwargs):
+                 i2c=None):
         # Check that mode is valid.
-        if mode not in [BME280_OSAMPLE_1, BME280_OSAMPLE_2, BME280_OSAMPLE_4,
-                        BME280_OSAMPLE_8, BME280_OSAMPLE_16]:
+        if mode not in range(1,6):
             raise ValueError(
                 'Unexpected mode value {0}. Set mode to one of '
-                'BME280_ULTRALOWPOWER, BME280_STANDARD, BME280_HIGHRES, or '
-                'BME280_ULTRAHIGHRES'.format(mode))
+                'BME280_OSAMPLE_1, BME280_OSAMPLE_2, BME280_OSAMPLE_4, '
+                'BME280_OSAMPLE_8 or BME280_OSAMPLE_16'.format(mode))
         self._mode = mode
         self.address = address
         if i2c is None:


### PR DESCRIPTION
This PR offers the following.
1. Produces a correct error message if the mode is invalid.
2. By removing constructor arg **kwargs an incorrectly spelled kwarg will now produce an exception rather than silently be accepted.
3. Minor suggestions such as use of constants to (minimally) reduce RAM usage.
